### PR TITLE
fix(install): resolve incorrect workspace dependency in web package

### DIFF
--- a/packages/web/package.json
+++ b/packages/web/package.json
@@ -34,7 +34,7 @@
     "toolbeam-docs-theme": "0.4.3"
   },
   "devDependencies": {
-    "opencode": "workspace:*",
+    "ai_redteam": "workspace:*",
     "@types/node": "catalog:",
     "typescript": "catalog:"
   }


### PR DESCRIPTION
This PR addresses a critical installation issue that prevents new users from setting up the project locally using `bun install`. The installation currently fails with a persistent error: `error: Workspace dependency "opencode" not found`.

#### Root Cause:
The issue is a remnant from the original `sst/opencode` repository that this project was forked from. While the primary package in `packages/opencode` was correctly renamed to `ai_redteam`, another package within the workspace, `packages/web`, still contained a dependency pointing to the old package name: `"opencode": "workspace:*"`.

This causes Bun's dependency resolver to fail, as it cannot find a package named `"opencode"` within the workspace.

#### Changes in this PR:
This PR makes one small but critical change to fix the installation process:

*   In `packages/web/package.json`, the incorrect dependency `"opencode": "workspace:*"` has been updated to `"ai_redteam": "workspace:*"`.

This change aligns the dependency with the package's actual name in the workspace, allowing `bun install` to correctly resolve the local package tree.

#### How to Test This Fix:
1.  Clone a fresh copy of the repository and switch to this branch.
2.  **Crucially, ensure no `bun.lock` file is present in the root directory.** If one exists from a previous failed attempt, delete it: `rm bun.lock`.
3.  Run the installation command from the project root:
    ```bash
    bun install
    ```
4.  The installation should now complete successfully.
5.  The development server can then be started as intended:
    ```bash
    bun dev
    ```

This fix should resolve the primary barrier for new contributors wanting to run and test the `pi-terminal` project.